### PR TITLE
Dynamically read, offer onboarding track choices and generate appropriate tasks from yaml file in web app view

### DIFF
--- a/app/controllers/app.go
+++ b/app/controllers/app.go
@@ -76,15 +76,13 @@ func (c App) Workload() revel.Result {
 	if err := c.Request.ParseForm(); err != nil {
 		revel.ERROR.Printf("Form not parsed correctly")
 	}
+	// read tracks chosen in form and assign to user
 	var tracks []string
-	// availableTracks := []string{"app_dev", "cluster_op", "cnct_hire"} //TODO this is where we'd just grab them from user
 	for _, track := range user.AvailableTracks {
 		if c.Params.Form.Get(track) != "" {
 			tracks = append(tracks, track)
 		}
 	}
-	revel.INFO.Println("tracks: ", tracks)
-
 	user.Tracks = tracks
 	if user == nil {
 		revel.ERROR.Printf("User not setup correctly")
@@ -93,14 +91,14 @@ func (c App) Workload() revel.Result {
 	return c.Render(user)
 }
 
-// Tracks handles the initial track choice rendering
+// Tracks handles the rendering of track choices available
 func (c App) Tracks() revel.Result {
-	//TODO: read possible tracks from yaml and assign them to User (possibly create yet another field)
 	user := c.currentUser()
 	if user == nil {
 		revel.ERROR.Printf("User not setup correctly")
 		return c.Redirect("/")
 	}
+	// assign tracks read from yaml to current user
 	user.AvailableTracks = app.Setup.AvailableTracks
 	return c.Render(user)
 }

--- a/app/controllers/app.go
+++ b/app/controllers/app.go
@@ -96,7 +96,7 @@ func (c App) Workload() revel.Result {
 	revel.INFO.Println(ttests)
 	revel.INFO.Println("tracks: ", tracks)
 
-	// user.Tracks = tracks
+	user.Tracks = tracks
 	if user == nil {
 		revel.ERROR.Printf("User not setup correctly")
 		return c.Redirect("/")

--- a/app/controllers/app.go
+++ b/app/controllers/app.go
@@ -77,17 +77,29 @@ func (c App) AuthCallback() revel.Result {
 }
 
 // Workload handles the initial workload page rendering
-func (c App) Workload(appDev, clusterOp, cnctHire string) revel.Result {
-	revel.INFO.Printf("The following tracks were chosen: %s, %s, %s", appDev, clusterOp, cnctHire)
+func (c App) Workload() revel.Result {
+	// revel.INFO.Printf("The following tracks were chosen: %s, %s, %s", appDev, clusterOp, cnctHire)
 	user := c.currentUser()
+	if err := c.Request.ParseForm(); err != nil {
+		revel.ERROR.Printf("Form not parsed correctly")
+	}
 	var tracks []string
-	tracks = append(tracks, appDev, clusterOp, cnctHire)
-	user.Tracks = tracks
+	availableTracks := []string{"app_dev", "cluster_op", "cnct_hire"}
+	for _, track := range availableTracks {
+		if c.Params.Form.Get(track) != "" {
+			tracks = append(tracks, track)
+		}
+	}
+
+	ttests := c.Params.Form.Get("appDev")
+	revel.INFO.Println(ttests)
+	revel.INFO.Println("tracks: ", tracks)
+
+	// user.Tracks = tracks
 	if user == nil {
 		revel.ERROR.Printf("User not setup correctly")
 		return c.Redirect("/")
 	}
-
 	return c.Render(user, tracks)
 }
 

--- a/app/controllers/app.go
+++ b/app/controllers/app.go
@@ -77,8 +77,8 @@ func (c App) Workload() revel.Result {
 		revel.ERROR.Printf("Form not parsed correctly")
 	}
 	var tracks []string
-	availableTracks := []string{"app_dev", "cluster_op", "cnct_hire"} //TODO this is where we'd just grab them from user
-	for _, track := range availableTracks {
+	// availableTracks := []string{"app_dev", "cluster_op", "cnct_hire"} //TODO this is where we'd just grab them from user
+	for _, track := range user.AvailableTracks {
 		if c.Params.Form.Get(track) != "" {
 			tracks = append(tracks, track)
 		}
@@ -101,11 +101,8 @@ func (c App) Tracks() revel.Result {
 		revel.ERROR.Printf("User not setup correctly")
 		return c.Redirect("/")
 	}
-	availableTracks := []string{"app_dev", "cluster_op", "cnct_hire"}
-	//TODO: make availableTracks a User thing and replace here
-	//TODO: Somehow make the string keys human readable
-
-	return c.Render(user, availableTracks)
+	user.AvailableTracks = app.Setup.AvailableTracks
+	return c.Render(user)
 }
 
 // WorkloadSocket handles the websocket connection for workload events

--- a/app/controllers/app.go
+++ b/app/controllers/app.go
@@ -99,8 +99,28 @@ func (c App) Tracks() revel.Result {
 		return c.Redirect("/")
 	}
 	// assign tracks read from yaml to current user
-	user.AvailableTracks = app.Setup.AvailableTracks
+	user.AvailableTracks = c.GetTracks()
 	return c.Render(user)
+}
+
+// GetTracks finds all available tracks from setup scheme information
+func (c App) GetTracks() []string {
+	taskList := app.Setup.Tasks
+	checkTracks := make(map[string]bool)
+	var possibleTracks []string
+	// iterate over tasks
+	for _, task := range taskList {
+		// iterate over tags
+		for _, tag := range task.Tags {
+			// check if tags are already in collection, and if not, append to possibleTracks
+			_, ok := checkTracks[tag]
+			if !ok {
+				checkTracks[tag] = true
+				possibleTracks = append(possibleTracks, tag)
+			}
+		}
+	}
+	return possibleTracks
 }
 
 // WorkloadSocket handles the websocket connection for workload events

--- a/app/controllers/app.go
+++ b/app/controllers/app.go
@@ -80,13 +80,9 @@ func (c App) Workload() revel.Result {
 	availableTracks := []string{"app_dev", "cluster_op", "cnct_hire"} //TODO this is where we'd just grab them from user
 	for _, track := range availableTracks {
 		if c.Params.Form.Get(track) != "" {
-			revel.INFO.Println("in for loop", track)
 			tracks = append(tracks, track)
 		}
 	}
-
-	ttests := c.Params.Form.Get("appDev")
-	revel.INFO.Println(ttests)
 	revel.INFO.Println("tracks: ", tracks)
 
 	user.Tracks = tracks
@@ -106,6 +102,8 @@ func (c App) Tracks() revel.Result {
 		return c.Redirect("/")
 	}
 	availableTracks := []string{"app_dev", "cluster_op", "cnct_hire"}
+	//TODO: make availableTracks a User thing and replace here
+	//TODO: Somehow make the string keys human readable
 
 	return c.Render(user, availableTracks)
 }

--- a/app/controllers/app.go
+++ b/app/controllers/app.go
@@ -87,6 +87,7 @@ func (c App) Workload() revel.Result {
 	availableTracks := []string{"app_dev", "cluster_op", "cnct_hire"}
 	for _, track := range availableTracks {
 		if c.Params.Form.Get(track) != "" {
+			revel.INFO.Println("in for loop", track)
 			tracks = append(tracks, track)
 		}
 	}

--- a/app/controllers/app.go
+++ b/app/controllers/app.go
@@ -28,12 +28,6 @@ func (c App) Index() revel.Result {
 	return c.Render()
 }
 
-// GetTrack gets form input
-func (c App) GetTrack(mytrack string) revel.Result {
-	revel.INFO.Printf("The track %s was chosen.", mytrack)
-	return c.Render(mytrack)
-}
-
 // Auth initiates the oauth2 authorization request to github
 func (c App) Auth() revel.Result {
 	user := c.currentUser()
@@ -73,18 +67,17 @@ func (c App) AuthCallback() revel.Result {
 	user.Username = auth.GithubUsername()
 
 	revel.INFO.Printf("Successfully authenticated Github user: %s\n", user.Username)
-	return c.Redirect("/tracks") //TODO: redirect to Tracks
+	return c.Redirect("/tracks")
 }
 
 // Workload handles the initial workload page rendering
 func (c App) Workload() revel.Result {
-	// revel.INFO.Printf("The following tracks were chosen: %s, %s, %s", appDev, clusterOp, cnctHire)
 	user := c.currentUser()
 	if err := c.Request.ParseForm(); err != nil {
 		revel.ERROR.Printf("Form not parsed correctly")
 	}
 	var tracks []string
-	availableTracks := []string{"app_dev", "cluster_op", "cnct_hire"}
+	availableTracks := []string{"app_dev", "cluster_op", "cnct_hire"} //TODO this is where we'd just grab them from user
 	for _, track := range availableTracks {
 		if c.Params.Form.Get(track) != "" {
 			revel.INFO.Println("in for loop", track)
@@ -101,18 +94,20 @@ func (c App) Workload() revel.Result {
 		revel.ERROR.Printf("User not setup correctly")
 		return c.Redirect("/")
 	}
-	return c.Render(user, tracks)
+	return c.Render(user)
 }
 
 // Tracks handles the initial track choice rendering
 func (c App) Tracks() revel.Result {
+	//TODO: read possible tracks from yaml and assign them to User (possibly create yet another field)
 	user := c.currentUser()
 	if user == nil {
 		revel.ERROR.Printf("User not setup correctly")
 		return c.Redirect("/")
 	}
+	availableTracks := []string{"app_dev", "cluster_op", "cnct_hire"}
 
-	return c.Render(user)
+	return c.Render(user, availableTracks)
 }
 
 // WorkloadSocket handles the websocket connection for workload events

--- a/app/controllers/app.go
+++ b/app/controllers/app.go
@@ -70,13 +70,12 @@ func (c App) AuthCallback() revel.Result {
 	return c.Redirect("/tracks")
 }
 
-// Workload handles the initial workload page rendering
+// Workload handles the initial workload page rendering, reads tracks chosen in form and assigns to current user
 func (c App) Workload() revel.Result {
 	user := c.currentUser()
 	if err := c.Request.ParseForm(); err != nil {
 		revel.ERROR.Printf("Form not parsed correctly")
 	}
-	// read tracks chosen in form and assign to user
 	var tracks []string
 	for _, track := range user.AvailableTracks {
 		if c.Params.Form.Get(track) != "" {
@@ -91,14 +90,13 @@ func (c App) Workload() revel.Result {
 	return c.Render(user)
 }
 
-// Tracks handles the rendering of track choices available
+// Tracks handles the rendering of track choices available and assigns them to current user
 func (c App) Tracks() revel.Result {
 	user := c.currentUser()
 	if user == nil {
 		revel.ERROR.Printf("User not setup correctly")
 		return c.Redirect("/")
 	}
-	// assign tracks read from yaml to current user
 	user.AvailableTracks = c.GetTracks()
 	return c.Render(user)
 }
@@ -108,11 +106,9 @@ func (c App) GetTracks() []string {
 	taskList := app.Setup.Tasks
 	checkTracks := make(map[string]bool)
 	var possibleTracks []string
-	// iterate over tasks
 	for _, task := range taskList {
-		// iterate over tags
 		for _, tag := range task.Tags {
-			// check if tags are already in collection, and if not, append to possibleTracks
+			// If tags are not already in collection, append to possibleTracks
 			_, ok := checkTracks[tag]
 			if !ok {
 				checkTracks[tag] = true

--- a/app/init.go
+++ b/app/init.go
@@ -117,7 +117,7 @@ func SetupScheme() {
 	configFilename := Configs[OnboardTasksFileName]
 	setup, err := onboarding.NewSetupScheme(configFilename, &Configs)
 	if err != nil {
-		revel.ERROR.Fatalf("Cannat create an onboarding github setup scheme: %v", err)
+		revel.ERROR.Fatalf("Cannot create an onboarding github setup scheme: %v", err)
 	}
 	Setup = setup
 	revel.INFO.Printf("Scheme Setup")

--- a/app/jobs/onboarding/config.go
+++ b/app/jobs/onboarding/config.go
@@ -15,7 +15,7 @@ type (
 		Title       string
 		Assignee    indirectAssignee `yaml:"assignee"`
 		Description string           `yaml:"description,omitempty"`
-		Tags        []string         `yaml:"tags,omitempty"` //TODO: add all the tags and determine if omitempty is what we want"
+		Tags        []string         `yaml:"tags,omitempty"`
 	}
 
 	indirectAssignee struct {
@@ -29,6 +29,7 @@ type (
 		GithubOrganization string                      `yaml:"githubOrganization"`
 		GithubRepository   string                      `yaml:"githubRepository"`
 		Tasks              []TaskEntry                 `yaml:"tasks"`
+		AvailableTracks    []string                    `yaml:"availableTracks"`
 		TaskOwners         map[string]indirectAssignee `yaml:"task_owners"`
 	}
 )

--- a/app/jobs/onboarding/config.go
+++ b/app/jobs/onboarding/config.go
@@ -67,7 +67,6 @@ func (setup *SetupScheme) load(filename string, environ *map[string]string) erro
 	if err != nil {
 		log.Fatal(err)
 	}
-
 	return setup.ingest(data, environ)
 }
 

--- a/app/jobs/onboarding/config.go
+++ b/app/jobs/onboarding/config.go
@@ -29,7 +29,6 @@ type (
 		GithubOrganization string                      `yaml:"githubOrganization"`
 		GithubRepository   string                      `yaml:"githubRepository"`
 		Tasks              []TaskEntry                 `yaml:"tasks"`
-		AvailableTracks    []string                    `yaml:"availableTracks"`
 		TaskOwners         map[string]indirectAssignee `yaml:"task_owners"`
 	}
 )

--- a/app/jobs/onboarding/workload.go
+++ b/app/jobs/onboarding/workload.go
@@ -193,7 +193,6 @@ func (job GenerateProject) Run() {
 	for _, task := range setup.Tasks {
 		for _, tag := range task.Tags {
 			fmt.Println(tag)
-			// TODO: get app-dev dynamically.
 			if CheckTracks(tracks, tag) {
 				job.New <- jobs.NewEvent(job.ID, "progress", fmt.Sprintf("Preparing Issue - %s", task.Title))
 				issue, err := repo.CreateOrUpdateIssue(&task.Assignee.GithubUsername, &task.Title, &task.Description, milestone.GetNumber())

--- a/app/models/user.go
+++ b/app/models/user.go
@@ -8,10 +8,11 @@ import (
 
 // User model object to manage user authentication
 type User struct {
-	ID       int
-	Username string
-	AuthEnv  *onboarding.AuthEnvironment
-	Tracks   []string
+	ID              int
+	Username        string
+	AuthEnv         *onboarding.AuthEnvironment
+	Tracks          []string
+	AvailableTracks []string
 }
 
 var db = make(map[int]*User)

--- a/app/views/App/Tracks.html
+++ b/app/views/App/Tracks.html
@@ -22,7 +22,7 @@
 
 <form action="/workload" method="POST">
     {{ range .availableTracks }}
-      <input type="checkbox" name={{.}} value={{.}}/> I'm an application developer<br/>
+      <input type="checkbox" name={{.}} value={{.}}/> I'm a{{.}}<br/>
     {{end}}
     <input type="submit" value="Submit" />
 </form>

--- a/app/views/App/Tracks.html
+++ b/app/views/App/Tracks.html
@@ -22,7 +22,7 @@
 
 <form action="/workload" method="POST">
     {{ range .user.AvailableTracks }}
-      <input type="checkbox" name={{.}} value={{.}}/> I'm a {{.}}<br/>
+      <input type="checkbox" name={{.}} value={{.}}/> {{.}}<br/>
     {{end}}
     <input type="submit" value="Submit" />
 </form>

--- a/app/views/App/Tracks.html
+++ b/app/views/App/Tracks.html
@@ -20,10 +20,10 @@
     Please choose from the following learning tracks. You may select more than one.
 </p>
 
-<form action="/workload" method="GET">
-    <input type="checkbox" name="appDev" value="app_dev"/> I'm an application developer<br/>
-    <input type="checkbox" name="clusterOp" value="cluster_op" /> I'm a cluster operator<br/>
-    <input type="checkbox" name="cnctHire" value="cnct_hire"/> I'm a new hire at CNCT<br/>
+<form action="/workload" method="POST">
+    <input type="checkbox" name="app_dev" value="app_dev"/> I'm an application developer<br/>
+    <input type="checkbox" name="cluster_op" value="cluster_op" /> I'm a cluster operator<br/>
+    <input type="checkbox" name="cnct_hire" value="cnct_hire"/> I'm a new hire at CNCT<br/>
     <input type="submit" value="Submit" />
 </form>
 

--- a/app/views/App/Tracks.html
+++ b/app/views/App/Tracks.html
@@ -21,9 +21,9 @@
 </p>
 
 <form action="/workload" method="POST">
-    <input type="checkbox" name="app_dev" value="app_dev"/> I'm an application developer<br/>
-    <input type="checkbox" name="cluster_op" value="cluster_op" /> I'm a cluster operator<br/>
-    <input type="checkbox" name="cnct_hire" value="cnct_hire"/> I'm a new hire at CNCT<br/>
+    {{ range .availableTracks }}
+      <input type="checkbox" name={{.}} value={{.}}/> I'm an application developer<br/>
+    {{end}}
     <input type="submit" value="Submit" />
 </form>
 

--- a/app/views/App/Tracks.html
+++ b/app/views/App/Tracks.html
@@ -21,8 +21,8 @@
 </p>
 
 <form action="/workload" method="POST">
-    {{ range .availableTracks }}
-      <input type="checkbox" name={{.}} value={{.}}/> I'm a{{.}}<br/>
+    {{ range .user.AvailableTracks }}
+      <input type="checkbox" name={{.}} value={{.}}/> I'm a {{.}}<br/>
     {{end}}
     <input type="submit" value="Submit" />
 </form>

--- a/conf/routes
+++ b/conf/routes
@@ -11,9 +11,8 @@ GET     /version                                App.Version
 GET     /auth                                   App.Auth
 GET     /authcb                                 App.AuthCallback
 GET     /workload                               App.Workload
-POST     /workload                               App.Workload
+POST     /workload                              App.Workload
 GET     /tracks                                 App.Tracks
-GET     /getTrack                               App.GetTrack
 WS      /workload/socket                        App.WorkloadSocket
 
 # Ignore favicon requests

--- a/conf/routes
+++ b/conf/routes
@@ -11,6 +11,7 @@ GET     /version                                App.Version
 GET     /auth                                   App.Auth
 GET     /authcb                                 App.AuthCallback
 GET     /workload                               App.Workload
+POST     /workload                               App.Workload
 GET     /tracks                                 App.Tracks
 GET     /getTrack                               App.GetTrack
 WS      /workload/socket                        App.WorkloadSocket

--- a/onboarding-issues.yaml
+++ b/onboarding-issues.yaml
@@ -19,7 +19,7 @@ tasks:
       3. Update the top section of the page, and add your name to the team member list.
       4. Familiarize yourself with [the wiki in general](https://samsung-cnct.atlassian.net/wiki/).
     tags:
-      - cnct_hire
+      - CNCT new hire
   - title: Update the Team's Bio Blurbs
     assignee: *new_hire
     description: |
@@ -27,8 +27,8 @@ tasks:
 
       `https://samsung-cnct.atlassian.net/wiki/spaces/AG/pages/1212557/Team+Bio+Blurbs`
     tags:
-      - app_dev
-      - cnct_hire
+      - Application Developer
+      - CNCT new hire
 
   - title: Log into tooling
     assignee: *new_hire
@@ -39,66 +39,67 @@ tasks:
       - [ ] Related Cloud Computing services (AWS, GCP/GKE, etc)
       - [ ] Slack
     tags:
-      - cnct_hire
+      - CNCT new hire
 
   - title: Read kraken-lib GitHub README
     assignee: *new_hire
     description: Reading is the new ... something.
     tags:
-      - cnct_hire
+      - CNCT new hire
 
   - title: Spin up Kubernetes cluster on AWS using kraken
     assignee: *new_hire
     description: |
       See also: `https://github.com/samsung-cnct/kraken`
     tags:
-      - app_dev
-      - cnct_hire
+      - Application Developer
+      - CNCT new hire
 
   - title: Spin up Kubernetes cluster on AWS using the base Docker image
     assignee: *new_hire
     description: |
       The easiest way to get started with kraken directly is to use a kraken container image:
       `docker pull quay.io/samsung_cnct/k2:latest`
+    tags:
 
   - title: Write a Golang app and deploy it onto your Kubernetes cluster
     assignee: *new_hire
     description: |
       Something fun and worth sharing, hopefully. :)
 
-  - title: Read the Kubernetes onboarding reference material
-    assignee: *new_hire
-    description: |
-      There is a lot of material in this list. Pick and choose what is more relevant and more helpful for you.
-      `https://samsung-cnct.atlassian.net/wiki/spaces/AG/pages/1212725/Onboarding+Reference+Material`
+  # - title: Read the Kubernetes onboarding reference material
+  #   assignee: *new_hire
+  #   description: |
+  #     There is a lot of material in this list. Pick and choose what is more relevant and more helpful for you.
+  #     `https://samsung-cnct.atlassian.net/wiki/spaces/AG/pages/1212725/Onboarding+Reference+Material`
 
-  - title: Learn basic Golang
-    assignee: *new_hire
-    description: |
-      Start here? `https://tour.golang.org/welcome/1`
+  # - title: Learn basic Golang
+  #   assignee: *new_hire
+  #   description: |
+  #     Start here? `https://tour.golang.org/welcome/1`
 
-      See also:
-        - [Kubernetes Coding Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/coding-conventions.md)
+  #     See also:
+  #       - [Kubernetes Coding Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/coding-conventions.md)
 
-  - title: Culture Lightning Talk
-    assignee: *new_hire
-    description: |
-      Create a non-technical lightning talk to let us get to know you better.
-      The topics can be anything important to you - culture, hobbies, history, language etc.
-      Please include pictures.
+  # - title: Culture Lightning Talk
+  #   assignee: *new_hire
+  #   description: |
+  #     Create a non-technical lightning talk to let us get to know you better.
+  #     The topics can be anything important to you - culture, hobbies, history, language etc.
+  #     Please include pictures.
 
-      You will present this to the whole team after general standup - please keep the talk between 4-5 minutes.
+  #     You will present this to the whole team after general standup - please keep the talk between 4-5 minutes.
 
-      Procedure:
-        - Create presentation.
-        - Pick a date to present and schedule this with your manager.
-        - Record lightning talk via Zoom.
-        - [Store on team share](https://github.com/samsung-cnct/media/tree/master/staff-info/lightening-talks)
-        - Link in your team bio entry in [confluence](https://samsung-cnct.atlassian.net/wiki/spaces/AG/pages/1212557/Team+Bio+Blurbs)
+  #     Procedure:
+  #       - Create presentation.
+  #       - Pick a date to present and schedule this with your manager.
+  #       - Record lightning talk via Zoom.
+  #       - [Store on team share](https://github.com/samsung-cnct/media/tree/master/staff-info/lightening-talks)
+  #       - Link in your team bio entry in [confluence](https://samsung-cnct.atlassian.net/wiki/spaces/AG/pages/1212557/Team+Bio+Blurbs)
 
-  - title: Read additional CNCT development documents
-    assignee: *new_hire
-    description: |
-      - [ ] Read about [community meetings](https://github.com/samsung-cnct/docs/blob/master/cnct/community-meetings.md)
-      - [ ] Read about [github usage](https://github.com/samsung-cnct/docs/blob/master/cnct/github.md)
-      - [ ] Read about [slack usage](https://github.com/samsung-cnct/docs/blob/master/cnct/slack.md)
+  # - title: Read additional CNCT development documents
+  #   assignee: *new_hire
+  #   description: |
+  #     - [ ] Read about [community meetings](https://github.com/samsung-cnct/docs/blob/master/cnct/community-meetings.md)
+  #     - [ ] Read about [github usage](https://github.com/samsung-cnct/docs/blob/master/cnct/github.md)
+  #     - [ ] Read about [slack usage](https://github.com/samsung-cnct/docs/blob/master/cnct/slack.md)


### PR DESCRIPTION
This pull request will read the possible task tracks from the onboarding yaml file task tags, generate onboarding tracks to choose from, present them to the user, and then generate a task board with tasks from each track chosen.

This is a perfectly workable solution that for generation of onboarding tracks only expects changes in the yaml file.

Future improvements should include:
- the app should not to generate tasks that were already generated under another track (i.e. have more than one track tag) since they generate messy error messages
- better ordering of tasks generated (due to pushing and popping from a channel these tasks appear in reverse order from the yaml file; in contrast a task board would be expected to list them in order of priority from top to bottom)
- testing for the yaml file processing operating as expected
- better rendering aesthetics on Tracks View

 