### PR TITLE
Improves user experience by screening for identical cards created by a different track in the same run

### DIFF
--- a/app/jobs/onboarding/workload.go
+++ b/app/jobs/onboarding/workload.go
@@ -192,11 +192,10 @@ func (job GenerateProject) Run() {
 	var cards []string
 	for _, task := range setup.Tasks {
 		for _, tag := range task.Tags {
-			fmt.Println("Hello", tag)
+			fmt.Println("Item tagged as:", tag)
 			if CheckTracks(tracks, tag) {
 				if CardExists(cards, task.Title) {
-					fmt.Println("HEEEEKWLKDLSFIDUFOOOOO")
-					fmt.Println("task was created by a previous track already")
+					fmt.Println("This task was created by a previous track already")
 				} else {
 					cards = append(cards, task.Title)
 					fmt.Println("HERE ARE THE CARDS:", cards)


### PR DESCRIPTION
With the option of choosing multiple tracks, it is possible for some issues to be identical across tracks. The user will see ugly error messages on the first run of creating a new project. This pull request screens for such doubles, and refrains from attempting to create duplicate issues.